### PR TITLE
Refatorar o layout do aplicativo para uma lista vertical de ícones qu…

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -51,33 +51,32 @@
             gap: 16px; /* Espaçamento entre os apps */
         }
         .app-container {
-            @apply flex flex-row items-center p-2 rounded-lg; /* Layout de linha para ícone e texto */
-            cursor: move;
-            width: 100%;
-            max-width: 300px; /* Largura máxima para os itens */
-        }
-        #button-grid-container .grid-item {
+            /* Os estilos foram movidos de .grid-item para cá para tornar o container o próprio ícone */
             background-color: #333;
             width: 56px;
             height: 56px;
-            border-radius: 12px !important; /* Ícone quadrado */
+            border-radius: 0; /* Ícone quadrado, sem cantos arredondados */
             display: flex;
             align-items: center;
             justify-content: center;
             transition: all 0.3s ease-in-out;
             box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-            flex-shrink: 0; /* Impede que o ícone encolha */
+            cursor: move;
         }
-        .grid-item:hover {
+        .app-container:hover {
             background-color: #1f2937; /* bg-gray-800 */
             box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1); /* shadow-lg */
+        }
+        #button-grid-container .grid-item {
+            /* Estilos agora estão no .app-container. Este seletor será obsoleto após a refatoração do JS. */
+            flex-shrink: 0;
         }
         .grid-item-icon {
             font-size: 1.5rem; /* Tamanho para celular (text-2xl) */
             color: white;
         }
         .grid-item-label {
-            @apply font-semibold text-gray-700 ml-4 text-lg; /* Estilo do texto ao lado do ícone */
+            display: none; /* Oculta o texto ao lado do ícone */
         }
         .app-container.dragging {
             @apply opacity-50 bg-gray-300;
@@ -2897,6 +2896,7 @@
                 appContainer.draggable = true;
                 appContainer.dataset.id = app.id;
                 appContainer.dataset.title = app.title;
+                appContainer.title = app.title; // Adiciona o tooltip nativo do browser
                 appContainer.dataset.isFixed = app.isFixed;
                 if (app.url) appContainer.dataset.url = app.url;
                 if (app.icon_class) appContainer.dataset.iconClass = app.icon_class;
@@ -2904,16 +2904,16 @@
                 appContainer.dataset.iconColor = app.icon_color;
 
                 const iconClass = app.isFixed ? app.iconClass : (app.icon_class || 'fas fa-link');
-                const bgColor = app.isFixed ? '' : `background-color: ${app.bg_color || '#333'}`;
                 const iconColor = app.isFixed ? '' : `color: ${app.icon_color || '#fff'}`;
 
-                appContainer.innerHTML = `
-                    <div class="grid-item" style="${bgColor}">
-                        <i class="${iconClass} grid-item-icon" style="${iconColor}"></i>
-                    </div>
-                    <span class="grid-item-label text-theme">${app.title}</span>
-                `;
+                // Aplica a cor de fundo personalizada para apps não fixos
+                if (!app.isFixed) {
+                    appContainer.style.backgroundColor = app.bg_color || '#333';
+                }
 
+                appContainer.innerHTML = `<i class="${iconClass} grid-item-icon" style="${iconColor}"></i>`;
+
+                // O evento de clique é agora adicionado ao próprio container do app
                 appContainer.addEventListener('click', () => {
                     if (isDragging) return;
                     showAppOptionsModal(app);


### PR DESCRIPTION
…adrados.

Esta alteração modifica a exibição dos aplicativos na tela principal, transformando-os de uma lista de texto e ícones em uma lista vertical de ícones quadrados.

- O CSS foi atualizado para que o `.app-container` se torne o próprio ícone quadrado, removendo os cantos arredondados e ocultando o texto.
- O JavaScript foi refatorado na função `renderApps` para gerar um HTML mais simples, adicionando o nome do aplicativo como uma dica de ferramenta (tooltip) e movendo o evento de clique para o contêiner do aplicativo.
- A funcionalidade de arrastar e soltar agora se aplica aos ícones quadrados e permanece restrita ao eixo vertical.