### PR TITLE
Fix: Ensure consistent icon size across all screen resolutions

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -58,8 +58,8 @@
         }
         #button-grid-container .grid-item {
             background-color: #333;
-            width: 56px;
-            height: 56px;
+            width: 56px !important; /* Tamanho fixo */
+            height: 56px !important; /* Tamanho fixo */
             border-radius: 12px; /* Ícone com cantos arredondados */
             display: flex;
             align-items: center;


### PR DESCRIPTION
This commit addresses a bug where application icons were resizing based on screen width, likely due to responsive styles from Tailwind CSS.

To enforce a consistent size, `!important` has been added to the `width` and `height` properties of the `.grid-item` style rule. This ensures the icons remain fixed at 56x56 pixels, preventing any unwanted layout shifts or resizing, regardless of the viewport dimensions.