### PR TITLE
Refatorar: Reverter para layout de ícone único com tooltip e sem efei…

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -51,35 +51,25 @@
             gap: 16px; /* Espaçamento entre os apps */
         }
         .app-container {
-            @apply flex flex-row items-center p-2 rounded-lg; /* Layout de linha para ícone e texto */
-            cursor: move;
-            width: 100%;
-            max-width: 300px; /* Largura máxima para os itens */
-        }
-        #button-grid-container .grid-item {
             background-color: #333;
-            width: 56px !important; /* Tamanho fixo */
-            height: 56px !important; /* Tamanho fixo */
+            width: 56px;
+            height: 56px;
             border-radius: 12px; /* Ícone com cantos arredondados */
             display: flex;
             align-items: center;
             justify-content: center;
             transition: all 0.3s ease-in-out;
             box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+            cursor: move;
             flex-shrink: 0; /* Impede que o ícone encolha */
         }
-        .grid-item:hover {
-            background-color: #1f2937; /* bg-gray-800 */
-            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1); /* shadow-lg */
-        }
+        /* Efeito de hover foi removido */
         .grid-item-icon {
             font-size: 1.5rem; /* Tamanho para celular (text-2xl) */
             color: white;
         }
         .grid-item-label {
-            @apply font-semibold text-gray-700 ml-4 text-sm; /* Fonte menor */
-            word-break: break-all; /* Quebra de linha agressiva */
-            max-width: calc(100% - 72px); /* Garante que não ultrapasse o container (56px do ícone + 16px de margem) */
+           display: none; /* O nome do aplicativo agora é um tooltip */
         }
         .app-container.dragging {
             @apply opacity-50 bg-gray-300;
@@ -2899,6 +2889,7 @@
                 appContainer.draggable = true;
                 appContainer.dataset.id = app.id;
                 appContainer.dataset.title = app.title;
+                appContainer.title = app.title; // Adiciona o tooltip nativo do browser
                 appContainer.dataset.isFixed = app.isFixed;
                 if (app.url) appContainer.dataset.url = app.url;
                 if (app.icon_class) appContainer.dataset.iconClass = app.icon_class;
@@ -2906,18 +2897,16 @@
                 appContainer.dataset.iconColor = app.icon_color;
 
                 const iconClass = app.isFixed ? app.iconClass : (app.icon_class || 'fas fa-link');
-                const bgColor = app.isFixed ? '' : `background-color: ${app.bg_color || '#333'}`;
                 const iconColor = app.isFixed ? '' : `color: ${app.icon_color || '#fff'}`;
 
-                appContainer.innerHTML = `
-                    <div class="grid-item" style="${bgColor}">
-                        <i class="${iconClass} grid-item-icon" style="${iconColor}"></i>
-                    </div>
-                    <span class="grid-item-label text-theme">${app.title}</span>
-                `;
+                // Aplica a cor de fundo personalizada para apps não fixos
+                if (!app.isFixed) {
+                    appContainer.style.backgroundColor = app.bg_color || '#333';
+                }
 
-                const gridItem = appContainer.querySelector('.grid-item');
-                gridItem.addEventListener('click', () => {
+                appContainer.innerHTML = `<i class="${iconClass} grid-item-icon" style="${iconColor}"></i>`;
+
+                appContainer.addEventListener('click', () => {
                     if (isDragging) return;
                     showAppOptionsModal(app);
                 });


### PR DESCRIPTION
…to de hover

Esta alteração reverte o layout da lista de aplicativos para um design de ícone único, em resposta ao feedback do usuário.

- A função `renderApps` em JavaScript foi modificada para remover o `<span>` do nome do aplicativo e, em vez disso, usar o atributo `title` para criar uma dica de ferramenta (tooltip) nativa.
- O CSS foi ajustado para remover a regra `:hover` que alterava a cor de fundo, eliminando o efeito visual.
- O contêiner `.app-container` foi reestilizado para funcionar como o próprio ícone de tamanho fixo, garantindo que a área de arrastar corresponda ao ícone.
- O nome do aplicativo, que era exibido ao lado do ícone, foi ocultado.
- O clique para abrir as opções do aplicativo foi movido do ícone para o contêiner do aplicativo, que agora é o próprio ícone.