### PR TITLE
Feat: Display app URL in the options modal

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -659,7 +659,10 @@
     <!-- Novo Modal de Opções do Aplicativo -->
     <div id="app-options-modal" class="fixed inset-0 bg-gray-100 hidden flex-col z-50">
         <header class="flex items-center justify-between p-4 bg-white shadow-md">
-            <h2 id="app-options-title" class="text-2xl font-bold truncate text-theme"></h2>
+            <div>
+                <h2 id="app-options-title" class="text-2xl font-bold truncate text-theme"></h2>
+                <p id="app-options-url" class="text-sm text-gray-500 truncate"></p>
+            </div>
             <button id="close-app-options-button" class="text-gray-500 hover:text-gray-700">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -1026,6 +1029,7 @@
         // Referências do novo modal de opções do aplicativo
         const appOptionsModal = document.getElementById('app-options-modal');
         const appOptionsTitle = document.getElementById('app-options-title');
+        const appOptionsUrl = document.getElementById('app-options-url'); // Novo
         const openAppButton = document.getElementById('open-app-button');
         const editAppButton = document.getElementById('edit-app-button');
         const deleteAppButton = document.getElementById('delete-app-button');
@@ -2977,8 +2981,10 @@
             const deleteAppText = document.getElementById('delete-app-text');
             if (app.isFixed) {
                 deleteAppText.textContent = 'Remover';
+                appOptionsUrl.textContent = ''; // Oculta o URL para apps fixos
             } else {
                 deleteAppText.textContent = 'Deletar';
+                appOptionsUrl.textContent = app.url || ''; // Mostra o URL
             }
 
             appOptionsTitle.textContent = app.title;


### PR DESCRIPTION
This commit enhances the app options modal by displaying the application's URL directly under its name, providing users with more context.

- An HTML `<p>` element with the ID `app-options-url` has been added to the `app-options-modal`.
- The `showAppOptionsModal` JavaScript function has been updated to populate this new element with the `app.url` from the dataset.
- The URL is only displayed for custom apps; it remains hidden for fixed apps like Shopping List and Notes.