### PR TITLE
fix: Remove tap highlight on profile button

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -168,6 +168,12 @@
         button {
             -webkit-tap-highlight-color: transparent;
         }
+        /* Correção para remover a borda de foco/toque no botão de perfil */
+        #profile-button:focus, #profile-button:active {
+            outline: none !important;
+            box-shadow: none !important;
+            -webkit-tap-highlight-color: transparent !important;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
Adds a specific CSS rule for the #profile-button element to remove the outline and tap highlight color on :focus and :active states.

This overrides the default browser behavior that was causing a brief black border to appear when the button was tapped on mobile devices, providing a cleaner user experience.