### PR TITLE
Refine notes filter UI and fix related bug

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -595,11 +595,11 @@
                     </svg>
                 </button>
         </header>
-        <div class="p-4 bg-white sticky top-0 z-10 shadow-sm flex justify-between items-center">
-            <button id="show-note-filter-modal-button" class="px-4 py-2 bg-gray-200 text-gray-800 font-semibold rounded-md hover:bg-gray-300">
-                Filtrar
+        <div class="p-4 bg-white sticky top-0 z-10 shadow-sm flex justify-start items-center space-x-4">
+            <button id="show-note-filter-modal-button" class="p-2 rounded-md hover:bg-gray-200 text-gray-600">
+                <i class="fas fa-filter text-xl"></i>
             </button>
-            <p class="font-semibold text-gray-600">Filtro: <span id="current-note-filter-display">Dia de Hoje</span></p>
+            <p id="current-note-filter-display" class="font-semibold text-lg text-gray-700">Notas de Hoje</p>
         </div>
         <div id="notes-container" class="flex-grow overflow-y-auto p-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 items-start">
             <!-- As notas serão inseridas aqui -->
@@ -2926,9 +2926,31 @@
             noteFilterModal.classList.remove('flex');
         }
 
-        function selectNoteFilter(filterValue, filterText) {
+        function updateNoteFilterDisplay(filterValue) {
+            let displayText = "Notas de Hoje"; // Default
+            switch (filterValue) {
+                case 'active':
+                    displayText = 'Notas de Hoje';
+                    break;
+                case 'futuras':
+                    displayText = 'Notas Futuras';
+                    break;
+                case 'antigas':
+                    displayText = 'Notas Antigas';
+                    break;
+                case 'fixed':
+                    displayText = 'Notas Fixas';
+                    break;
+                case 'all':
+                    displayText = 'Ver Tudo';
+                    break;
+            }
+            currentNoteFilterDisplay.textContent = displayText;
+        }
+
+        function selectNoteFilter(filterValue) {
             currentNoteFilter = filterValue;
-            currentNoteFilterDisplay.textContent = filterText;
+            updateNoteFilterDisplay(filterValue);
             fetchNotes();
             hideNoteFilterModal();
         }
@@ -2939,8 +2961,7 @@
         noteFilterOptions.forEach(button => {
             button.addEventListener('click', () => {
                 const filterValue = button.dataset.filter;
-                const filterText = button.textContent;
-                selectNoteFilter(filterValue, filterText);
+                selectNoteFilter(filterValue);
             });
         });
 
@@ -3382,7 +3403,7 @@
             } else if (appId === 'notes-app') {
                 notesModal.classList.remove('hidden');
                 notesModal.classList.add('flex');
-                setActiveNoteFilter(currentNoteFilter);
+                updateNoteFilterDisplay(currentNoteFilter);
                 fetchNotes();
             } else if (appId === 'recipes-app') { // NOVO
                 recipesModal.classList.remove('hidden');


### PR DESCRIPTION
- Replaced the text-based "Filtrar" button in the notes header with a filter icon for a cleaner look.
- Updated the filter status text to be more descriptive (e.g., "Notas de Hoje", "Notas Futuras").
- Aligned both the filter icon and status text to the left side of the header.
- Refactored the JavaScript by creating a new `updateNoteFilterDisplay` function to handle the new display text logic, separating it from the filter selection state management.
- Fixed a latent bug where the filter display text was not being correctly updated when the notes app was opened. The `openAppButton` event listener now calls the new `updateNoteFilterDisplay` function.