### PR TITLE
Update restore button text to 'Tirar do baú'

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -3305,7 +3305,7 @@
                 // Define the buttons based on whether the app is fixed or custom
                 const buttonsHtml = `
                     <div class="flex items-center space-x-2">
-                        <button data-id="${app.id}" class="restore-app-button px-4 py-2 bg-green-500 text-white font-semibold rounded-md hover:bg-green-600">Restaurar</button>
+                        <button data-id="${app.id}" class="restore-app-button px-4 py-2 bg-green-500 text-white font-semibold rounded-md hover:bg-green-600">Tirar do baú</button>
                         ${!app.isFixed ? `<button data-id="${app.id}" data-title="${app.title}" class="delete-app-permanently-button px-4 py-2 bg-red-500 text-white font-semibold rounded-md hover:bg-red-600">Excluir</button>` : ''}
                     </div>
                 `;


### PR DESCRIPTION
- Modified the `renderTrashList` JavaScript function to change the text of the restore button from "Restaurar" to "Tirar do baú" (Take out of the chest).
- This change aligns the button's text with the new 'Baú' (Chest) concept for the trash/archive functionality.