### PR TITLE
Update 'Baú' modal buttons to icons

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -3305,8 +3305,12 @@
                 // Define the buttons based on whether the app is fixed or custom
                 const buttonsHtml = `
                     <div class="flex items-center space-x-2">
-                        <button data-id="${app.id}" class="restore-app-button px-4 py-2 bg-green-500 text-white font-semibold rounded-md hover:bg-green-600">Tirar do baú</button>
-                        ${!app.isFixed ? `<button data-id="${app.id}" data-title="${app.title}" class="delete-app-permanently-button px-4 py-2 bg-red-500 text-white font-semibold rounded-md hover:bg-red-600">Excluir</button>` : ''}
+                        <button data-id="${app.id}" class="restore-app-button w-10 h-10 flex items-center justify-center rounded-full bg-green-500 text-white hover:bg-green-600 transition-colors" title="Tirar do baú">
+                            <i class="fas fa-undo"></i>
+                        </button>
+                        ${!app.isFixed ? `<button data-id="${app.id}" data-title="${app.title}" class="delete-app-permanently-button w-10 h-10 flex items-center justify-center rounded-full bg-red-500 text-white hover:bg-red-600 transition-colors" title="Excluir Permanentemente">
+                            <i class="fas fa-trash"></i>
+                        </button>` : ''}
                     </div>
                 `;
 


### PR DESCRIPTION
- Replaced the text-based 'Tirar do baú' button with an icon-only button featuring an 'undo' icon (`fa-undo`).
- Replaced the text-based 'Excluir' button with an icon-only button featuring a 'trash' icon (`fa-trash`).
- Adjusted the styling of the buttons to be circular and consistent with other icon buttons in the application.