### PR TITLE
Center-align user profile cards on selection screen

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -21,15 +21,15 @@
             color: var(--text-primary);
         }
         .user-card {
-            @apply flex flex-row items-center p-4 bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 cursor-pointer w-full max-w-sm;
+            @apply flex flex-col items-center justify-center text-center p-4 bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 cursor-pointer w-48 h-48;
         }
         .user-avatar {
             width: 80px;
             height: 80px;
-            @apply rounded-full object-cover mr-4;
+            @apply rounded-full object-cover mb-4;
         }
         .user-email {
-            @apply text-xl text-gray-800 font-semibold;
+            @apply text-lg text-gray-800 font-semibold truncate;
         }
         .shopping-list-item {
             @apply flex items-center justify-between p-3 border-b border-gray-200;
@@ -194,7 +194,7 @@
 
             <!-- Lista de Usuários (inicialmente escondida) -->
             <div id="user-list-container" class="hidden fixed inset-0 bg-gray-100 flex flex-col items-center justify-center gap-8 p-4">
-                <div id="user-cards-wrapper" class="flex flex-col items-center gap-4 w-full">
+                <div id="user-cards-wrapper" class="flex flex-wrap justify-center gap-4 max-w-4xl">
                     <!-- Usuários serão injetados aqui via JavaScript -->
                 </div>
                 <button id="back-to-initial-button" class="absolute top-6 left-6 px-4 py-2 bg-white text-gray-800 font-semibold rounded-md shadow-sm hover:bg-gray-200 focus:outline-none transition-all flex items-center">
@@ -1200,12 +1200,12 @@
             } else {
                 userCardsWrapper.innerHTML = '';
                 data.forEach(user => {
-                    const userCard = document.createElement('div');
+                    const userCard = document.createElement('button');
                     userCard.className = 'user-card';
                     userCard.dataset.email = user.username;
                     const avatarSrc = user.avatar_url || `https://placehold.co/80x80/A0A0A0/FFFFFF?text=${(user.profile_name || user.username).charAt(0).toUpperCase()}`;
                     userCard.innerHTML = `
-                        <img src="${avatarSrc}" alt="Profile" class="user-avatar w-20 h-20 rounded-full">
+                        <img src="${avatarSrc}" alt="Profile" class="user-avatar">
                         <p class="user-email">${user.profile_name || user.username}</p>
                     `;
                     userCardsWrapper.appendChild(userCard);


### PR DESCRIPTION
- Modified the CSS for `.user-card` to use a vertical column layout (`flex-col`) and center its content, achieving the requested centered look.
- Adjusted the margin on the `.user-avatar` to create space between the avatar and the name below it.
- Reverted the `#user-cards-wrapper` to a wrapping flexbox layout to better accommodate the card-based design.
- Updated the `fetchUsers` function to generate a semantic `<button>` for each user card and removed redundant inline styles.