### PR TITLE
fix: Correctly center user cards in vertical list

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -21,7 +21,7 @@
             color: var(--text-primary);
         }
         .user-card {
-            @apply flex flex-row items-center justify-center text-left p-4 bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 cursor-pointer w-full;
+            @apply flex flex-row items-center p-4 bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 cursor-pointer;
         }
         .user-avatar {
             width: 56px; /* Reduced size slightly */


### PR DESCRIPTION
This commit provides a definitive fix for the horizontal centering of user cards on the user selection screen.

The previous implementation, which used `justify-center` on a full-width card, caused misalignment for usernames of varying lengths.

This has been corrected by removing the width and justification properties from the `.user-card` class itself. The parent container (`#user-cards-wrapper`), which already has `items-center`, now correctly centers the entire user card (avatar and name) as a single, self-sizing unit. This ensures proper alignment regardless of the username's length.